### PR TITLE
ci: pin golangci-lint version instead of latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
+          version: v2.12.2
           working-directory: pogo-pvp-mcp
 
   test:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
-          version: latest
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
+          version: v2.12.2
           working-directory: pogo-pvp-mcp
 
   test:

--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,15 @@
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
       "automerge": true
     }
+  ],
+  "customManagers": [
+    {
+      "description": "Bump tool versions annotated with a renovate comment in workflows",
+      "customType": "regex",
+      "fileMatch": ["\\.github/workflows/.*\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*)\\n.*?[\"']?(?<currentValue>v?\\d+\\.\\d+\\.\\d+)[\"']?"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
`golangci-lint-action` ran with `version: latest` in both `pr.yml` and `ci.yml`, so any new linter release could surface findings and turn the required Lint check red with no code change (which is what happened when v2.12 tightened goconst). Pin to v2.12.2 (the current release) and add a renovate `customManager` parsing the `# renovate:` annotation, so the version is bumped by a controlled PR instead of silently breaking. Config-only.